### PR TITLE
fix to work with nan 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "url": "http://github.com/LinusU/fs-xattr.git"
   },
   "dependencies": {
-    "nan": "^1.4.1"
+    "nan": "^1.5.1"
   }
 }

--- a/src/xattr.cc
+++ b/src/xattr.cc
@@ -57,7 +57,7 @@ NAN_METHOD(xattr_get) {
 
   Local<Object> globalObj = NanGetCurrentContext()->Global();
   Local<Function> bufferConstructor = Local<Function>::Cast(globalObj->Get(NanNew("Buffer")));
-  Handle<Value> constructorArgs[3] = { slowBuffer, NanNew<Integer>(valueLen), NanNew<Integer>(0) };
+  Handle<Value> constructorArgs[3] = { slowBuffer, NanNew<Integer>((int32_t)valueLen), NanNew<Integer>(0) };
   Local<Object> actualBuffer = bufferConstructor->NewInstance(3, constructorArgs);
 
   NanReturnValue(actualBuffer);


### PR DESCRIPTION
The problem is documented here: https://github.com/rvagg/nan/issues/233

There would have been an implicit down-cast before, since javascript (and hence V8) doesn't support 64-bit integers.  Now it's explicit.