### PR TITLE
Lock down nan version to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "url": "http://github.com/LinusU/fs-xattr.git"
   },
   "dependencies": {
-    "nan": "^1.7.0"
+    "nan": "~1.8.0"
   }
 }


### PR DESCRIPTION
1.9.0 causes compilation errors. Rather than fixing the code we changed the required version.