### PR TITLE
specify compatible operating systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "dependencies": {
     "buffer-from": "^0.1.1",
     "nan": "^2.3.2"
-  }
+  },
+  "os": [
+    "!win32"
+  ]
 }


### PR DESCRIPTION
Since this module is not compatible with windows, it should be specified. Making it an optionalDependency is feasible, but sometime it could be dangerous.
https://stackoverflow.com/questions/15176082/npm-package-json-os-specific-dependency 