### PR TITLE
💥 Drop support for Node.js 0.10 and 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,10 @@
 language: node_js
 
-# For Node.js 4 and up we need to install C++11 compatible compiler
 matrix:
   include:
 
+    # For Node.js 4 and up we need to install C++11 compatible compiler
     # Travis' Linux machines doesn't support xattrs, just try building
-    - node_js: '0.10'
-      install: [npm install --ignore-scripts]
-      script: [npm install, npm run lint]
-      os: linux
-    - node_js: '0.12'
-      install: [npm install --ignore-scripts]
-      script: [npm install, npm run lint]
-      os: linux
     - node_js: '4'
       install: [npm install --ignore-scripts]
       script: [npm install, npm run lint]
@@ -20,6 +12,12 @@ matrix:
       env: [CXX=g++-4.8]
       os: linux
     - node_js: '6'
+      install: [npm install --ignore-scripts]
+      script: [npm install, npm run lint]
+      addons: {apt: {sources: [ubuntu-toolchain-r-test], packages: [g++-4.8]}}
+      env: [CXX=g++-4.8]
+      os: linux
+    - node_js: '8'
       install: [npm install --ignore-scripts]
       script: [npm install, npm run lint]
       addons: {apt: {sources: [ubuntu-toolchain-r-test], packages: [g++-4.8]}}
@@ -27,11 +25,9 @@ matrix:
       os: linux
 
     # Normal build for OS X
-    - node_js: '0.10'
-      os: osx
-    - node_js: '0.12'
-      os: osx
     - node_js: '4'
       os: osx
     - node_js: '6'
+      os: osx
+    - node_js: '8'
       os: osx

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-var addon = require('./build/Release/xattr')
-var bufferFrom = require('buffer-from')
+'use strict'
+
+const addon = require('./build/Release/xattr')
+const bufferFrom = require('buffer-from')
 
 function defaultCallback (err) {
   if (err) throw err
@@ -22,7 +24,7 @@ function validateArgument (key, val) {
       if (val == null) return defaultCallback
       throw new TypeError('`cb` must be a function')
     default:
-      throw new Error('Unknown argument: ' + key)
+      throw new Error(`Unknown argument: ${key}`)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "standard": "^10.0.3"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=4"
   },
   "os": [
     "!win32"

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ npm install --save fs-xattr
 ## Usage
 
 ```javascript
-var xattr = require('fs-xattr')
+const xattr = require('fs-xattr')
 ```
 
 ## API

--- a/test/xattr.js
+++ b/test/xattr.js
@@ -1,19 +1,21 @@
 /* eslint-env mocha */
 
-var xattr = require('../')
+'use strict'
 
-var fs = require('fs')
-var temp = require('fs-temp')
-var assert = require('assert')
-var crypto = require('crypto')
+const xattr = require('../')
 
-var attribute0 = 'com.linusu.test'
-var attribute1 = 'com.linusu.secondary'
-var payload0 = crypto.randomBytes(24).toString('hex')
-var payload1 = crypto.randomBytes(24).toString('hex')
+const fs = require('fs')
+const temp = require('fs-temp')
+const assert = require('assert')
+const crypto = require('crypto')
+
+const attribute0 = 'com.linusu.test'
+const attribute1 = 'com.linusu.secondary'
+const payload0 = crypto.randomBytes(24).toString('hex')
+const payload1 = crypto.randomBytes(24).toString('hex')
 
 describe('xattr#sync', function () {
-  var path
+  let path
 
   before(function () {
     path = temp.writeFileSync('')
@@ -25,13 +27,13 @@ describe('xattr#sync', function () {
   })
 
   it('should get an attribute', function () {
-    var val = xattr.getSync(path, attribute0)
+    const val = xattr.getSync(path, attribute0)
     assert(Buffer.isBuffer(val))
     assert.equal(val, payload0)
   })
 
   it('should list the attributes', function () {
-    var val = xattr.listSync(path)
+    const val = xattr.listSync(path)
     assert.ok(~val.indexOf(attribute0))
     assert.ok(~val.indexOf(attribute1))
   })
@@ -57,7 +59,7 @@ describe('xattr#sync', function () {
 })
 
 describe('xattr#async', function () {
-  var path
+  let path
 
   before(function () {
     path = temp.writeFileSync('')
@@ -111,7 +113,7 @@ describe('xattr#async', function () {
 })
 
 describe('xattr#utf8', function () {
-  var path
+  let path
 
   before(function () {
     path = temp.template('∞ %s').writeFileSync('')


### PR DESCRIPTION
Migration guide:

Upgrade to at least Node.js 4 for continued support.