### PR TITLE
feat: add missing `node-gyp` dev dep & add the missing build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
   ],
   "scripts": {
     "test": "standard && mocha && ts-readme-generator --check",
-    "lint": "standard"
+    "lint": "standard",
+    "build": "npx node-gyp build"
   },
   "devDependencies": {
     "fs-temp": "^1.1.2",
     "mocha": "^8.4.0",
+    "node-gyp": "^8.2.0",
     "standard": "^16.0.3",
     "ts-readme-generator": "^0.4.3"
   },


### PR DESCRIPTION
should've always been here, esp the build script.
had to read through [1] to figure it out smh - is there anything missing?

[1] https://medium.com/jspoint/a-simple-guide-to-load-c-c-code-into-node-js-javascript-applications-3fcccf54fd32

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>