### PR TITLE
fix: switch back from esm to cjs / provide cjs fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-import { createRequire } from 'node:module'
-
-const addon = createRequire(import.meta.url)('./build/Release/xattr')
+const path = require('path')
+const addon = require(path.join(__dirname, './build/Release/xattr.node'))
 
 function validateArgument (key, val) {
   switch (key) {
@@ -21,14 +20,14 @@ function validateArgument (key, val) {
 
 /* Async methods */
 
-export function getAttribute (path, attr) {
+function getAttribute (path, attr) {
   path = validateArgument('path', path)
   attr = validateArgument('attr', attr)
 
   return addon.get(path, attr)
 }
 
-export function setAttribute (path, attr, value) {
+function setAttribute (path, attr, value) {
   path = validateArgument('path', path)
   attr = validateArgument('attr', attr)
   value = validateArgument('value', value)
@@ -36,13 +35,13 @@ export function setAttribute (path, attr, value) {
   return addon.set(path, attr, value)
 }
 
-export function listAttributes (path) {
+function listAttributes (path) {
   path = validateArgument('path', path)
 
   return addon.list(path)
 }
 
-export function removeAttribute (path, attr) {
+function removeAttribute (path, attr) {
   path = validateArgument('path', path)
   attr = validateArgument('attr', attr)
 
@@ -51,14 +50,14 @@ export function removeAttribute (path, attr) {
 
 /* Sync methods */
 
-export function getAttributeSync (path, attr) {
+function getAttributeSync (path, attr) {
   path = validateArgument('path', path)
   attr = validateArgument('attr', attr)
 
   return addon.getSync(path, attr)
 }
 
-export function setAttributeSync (path, attr, value) {
+function setAttributeSync (path, attr, value) {
   path = validateArgument('path', path)
   attr = validateArgument('attr', attr)
   value = validateArgument('value', value)
@@ -66,15 +65,26 @@ export function setAttributeSync (path, attr, value) {
   return addon.setSync(path, attr, value)
 }
 
-export function listAttributesSync (path) {
+function listAttributesSync (path) {
   path = validateArgument('path', path)
 
   return addon.listSync(path)
 }
 
-export function removeAttributeSync (path, attr) {
+function removeAttributeSync (path, attr) {
   path = validateArgument('path', path)
   attr = validateArgument('attr', attr)
 
   return addon.removeSync(path, attr)
+}
+
+module.exports = {
+  getAttribute,
+  getAttributeSync,
+  setAttribute,
+  setAttributeSync,
+  listAttributes,
+  listAttributesSync,
+  removeAttribute,
+  removeAttributeSync
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.4.0",
   "license": "MIT",
   "repository": "LinusU/fs-xattr",
-  "type": "module",
   "exports": "./index.js",
   "files": [
     "binding.gyp",


### PR DESCRIPTION
We want to use this package together w/ `tsc` and sometimes with `ts-node[-dev]` as well.

We've been debugging various issues when trying to implement this, and
the only thing that helped was using cjs instead of esm.

Currently we have [1] a fork of this repo as a git submodule, with the
submitted PRs implemented in a separate branch, and use that directly
instead of an npm package - it works great, but this is far from ideal
and going back to cjs / using it in general means better compatibility
for _all_ of your consumers - both those using cjs and esm.
This does _not_ apply the other way around, and that's why it's an
issue for us that this package is with esm.

[1] https://github.com/kiprasmel/using-fs-xattr-with-ts

If this deems unacceptible, could you keep the things as-is,
but also create a separate file that uses cjs
which we could import from the npm package
something similar to this:

```js
import { getAttribute } from "xattr/cjs"
```

or similar?

---

see also:
https://twitter.com/Rich_Harris/status/1441068317930819589